### PR TITLE
女性限定イベント機能を追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,9 +63,17 @@ group :development do
   gem 'rubocop-rails', require: false
 end
 
+group :test do
+  gem 'capybara', '~> 3.23'
+  gem 'selenium-webdriver', '4.9.0'
+  gem 'webdrivers'
+end
+
 group :production do
   gem 'pg'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
+
+gem 'nokogiri', '1.12.5'

--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,7 @@ group :development do
   gem 'rack-mini-profiler', '~> 2.0'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
+  gem 'pry-byebug'
 
   gem 'letter_opener_web'
   gem 'rubocop', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,6 +106,15 @@ GEM
       msgpack (~> 1.0)
     builder (3.2.4)
     byebug (11.1.3)
+    capybara (3.39.1)
+      addressable
+      matrix
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (>= 1.5, < 3.0)
+      xpath (~> 3.2)
     concurrent-ruby (1.1.9)
     crass (1.0.6)
     diff-lcs (1.4.4)
@@ -173,6 +182,7 @@ GEM
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     marcel (1.0.2)
+    matrix (0.4.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
     minitest (5.14.4)
@@ -284,6 +294,7 @@ GEM
       rubocop (>= 1.7.0, < 2.0)
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
+    rubyzip (2.3.2)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.4.0)
@@ -294,6 +305,10 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
+    selenium-webdriver (4.9.0)
+      rexml (~> 3.2, >= 3.2.5)
+      rubyzip (>= 1.2.2, < 3.0)
+      websocket (~> 1.0)
     semantic_range (3.0.0)
     sorcery (0.16.1)
       bcrypt (~> 3.1)
@@ -318,14 +333,21 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webdrivers (5.2.0)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (~> 4.0)
     webpacker (5.4.3)
       activesupport (>= 5.2)
       rack-proxy (>= 0.6.1)
       railties (>= 5.2)
       semantic_range (>= 2.3.0)
+    websocket (1.2.9)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
     zeitwerk (2.5.1)
 
 PLATFORMS
@@ -337,6 +359,7 @@ DEPENDENCIES
   aws-sdk-s3
   bootsnap (>= 1.4.4)
   byebug
+  capybara (~> 3.23)
   draper
   enum_help
   factory_bot_rails
@@ -346,6 +369,7 @@ DEPENDENCIES
   kaminari!
   letter_opener_web
   listen (~> 3.3)
+  nokogiri (= 1.12.5)
   pg
   puma (~> 5.0)
   rack-mini-profiler (~> 2.0)
@@ -357,11 +381,13 @@ DEPENDENCIES
   rubocop
   rubocop-rails
   sass-rails (>= 6)
+  selenium-webdriver (= 4.9.0)
   sorcery
   spring
   sqlite3 (~> 1.4)
   tzinfo-data
   web-console (>= 4.1.0)
+  webdrivers
   webpacker (~> 5.0)
 
 RUBY VERSION

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,6 +115,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    coderay (1.1.3)
     concurrent-ruby (1.1.9)
     crass (1.0.6)
     diff-lcs (1.4.4)
@@ -206,6 +207,12 @@ GEM
     parser (3.0.2.0)
       ast (~> 2.4.1)
     pg (1.2.3)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.10.1)
+      byebug (~> 11.0)
+      pry (>= 0.13, < 0.15)
     public_suffix (4.0.6)
     puma (5.5.2)
       nio4r (~> 2.0)
@@ -371,6 +378,7 @@ DEPENDENCIES
   listen (~> 3.3)
   nokogiri (= 1.12.5)
   pg
+  pry-byebug
   puma (~> 5.0)
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.4, >= 6.1.4.1)

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -60,6 +60,6 @@ class EventsController < ApplicationController
   private
 
   def event_params
-    params.require(:event).permit(:title, :content, :held_at, :prefecture_id, :thumbnail)
+    params.require(:event).permit(:title, :content, :held_at,:only_woman, :prefecture_id, :thumbnail)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -17,6 +17,6 @@ class UsersController < ApplicationController
   end
 
   def user_params
-    params.require(:user).permit(:email, :name, :password, :password_confirmation)
+    params.require(:user).permit(:email, :name, :password, :password_confirmation, :gender)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,7 +21,7 @@ class User < ApplicationRecord
   validates :email, uniqueness: true
   validates :gender, presence: true
 
-  enum gender: {man: 0, woman: 1}
+  enum gender: {other: 0, man: 1, woman: 2}
 
   scope :allowing_created_event_notification,
         -> { joins(:notification_timings).merge(NotificationTiming.created_event) }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,6 +19,9 @@ class User < ApplicationRecord
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }
 
   validates :email, uniqueness: true
+  validates :gender, presence: true
+
+  enum gender: {man: 0, woman: 1}
 
   scope :allowing_created_event_notification,
         -> { joins(:notification_timings).merge(NotificationTiming.created_event) }

--- a/app/views/events/_event.html.erb
+++ b/app/views/events/_event.html.erb
@@ -20,6 +20,10 @@
         </div>
       </div>
       <hr />
+      <% if event.only_woman %>
+        <p class="card-text">女性限定</p>
+        <hr />
+      <% end %>
       <div class="d-flex align-items-center justify-content-between">
         <div class="d-flex align-items-center gap-3">
           <%= image_tag event.user.decorate.avatar, class: 'avatar-sm rounded-circle' %>

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -16,6 +16,12 @@
     <%= f.label :prefecture_id %>
     <%= f.collection_select :prefecture_id, Prefecture.all, :id, :name, {}, class: 'form-select' %>
   </div>
+  <% if current_user.woman? %>
+    <div class="mb-3">
+      <%= f.label :only_woman %>
+      <%= f.check_box :only_woman, {} , true, false %>
+    </div>
+  <% end%>
   <div class="mb-3">
     <%= f.label :thumbnail %>
     <%= f.file_field :thumbnail, class: 'form-control js-file-select-preview mb-3', accept: 'image/*', data: { target: '#preview-target' } %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -45,6 +45,10 @@
         </div>
         <div class="card-body">
           <%= simple_format @event.content %>
+          <hr />
+          <% if @event.only_woman %>
+            <p class="card-text">女性限定</p>
+          <% end %>
         </div>
       </div>
     </div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -97,12 +97,23 @@
                               data: { confirm: 'キャンセルします' }
                   %>
                 <% else %>
-                  <%= link_to 'このもくもく会に参加する',
+                  <% if @event.only_woman? %>
+                    <% if current_user.woman? %>
+                      <%= link_to 'このもくもく会に参加する',
+                                event_attendance_url(@event),
+                                class: 'btn btn-primary',
+                                method: :post,
+                                data: { confirm: '申し込みます' }
+                      %>
+                    <% end %>
+                  <% else %>
+                    <%= link_to 'このもくもく会に参加する',
                               event_attendance_url(@event),
                               class: 'btn btn-primary',
                               method: :post,
                               data: { confirm: '申し込みます' }
-                  %>
+                    %>
+                  <%end%>
                 <% end %>
               <% end %>
             <% end %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -32,6 +32,10 @@
               <%= f.password_field :password_confirmation, class: 'form-control' %>
             </div>
             <div class="mb-3">
+              <%= f.label :gender%>
+              <%= f.select :gender, User.genders_i18n.invert, {}, class: 'form-control'%>
+            </div>
+            <div class="mb-3">
               <div class="form-check">
                 <input type="checkbox" class="form-check-input" id="agreeCheck">
                 <label class="form-check-label" for="agreeCheck"><span>I agree to the <a href="terms-condition-page.html">Terms of

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -6,3 +6,7 @@ ja:
         commented_to_event: あなたのイベントにコメントがあった時
         attended_to_event: あなたのイベントに参加申し込みがあった時
         liked_event: あなたのイベントにいいねがついた時
+    user:
+      gender:
+        man: '男性'
+        woman: '女性'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -8,5 +8,6 @@ ja:
         liked_event: あなたのイベントにいいねがついた時
     user:
       gender:
+        other: 'その他'
         man: '男性'
         woman: '女性'

--- a/db/migrate/20230516150228_add_gender_to_users.rb
+++ b/db/migrate/20230516150228_add_gender_to_users.rb
@@ -1,0 +1,5 @@
+class AddGenderToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :gender, :integer, null: false, default: 0
+  end
+end

--- a/db/migrate/20230516155336_add_only_woman_to_events.rb
+++ b/db/migrate/20230516155336_add_only_woman_to_events.rb
@@ -1,0 +1,5 @@
+class AddOnlyWomanToEvents < ActiveRecord::Migration[6.1]
+  def change
+    add_column :events, :only_woman, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_05_16_150228) do
+ActiveRecord::Schema.define(version: 2023_05_16_155336) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -78,6 +78,7 @@ ActiveRecord::Schema.define(version: 2023_05_16_150228) do
     t.integer "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "only_woman", default: false, null: false
     t.index ["prefecture_id"], name: "index_events_on_prefecture_id"
     t.index ["user_id"], name: "index_events_on_user_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_19_072358) do
+ActiveRecord::Schema.define(version: 2023_05_16_150228) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -135,6 +135,7 @@ ActiveRecord::Schema.define(version: 2022_01_19_072358) do
     t.string "name", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "gender", default: 0, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -8,4 +8,9 @@ FactoryBot.define do
     prefecture_id { [*1..47].sample }
     user
   end
+
+  trait :woman_only_event do
+    only_woman { true }
+    user { FactoryBot.create(:user, :woman_user) }
+  end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -6,5 +6,9 @@ FactoryBot.define do
     name { Faker::Name.name }
     password { 'password' }
     password_confirmation { 'password' }
+
+    trait :woman_user do
+      gender { :woman }
+    end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,6 +7,7 @@ require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production
 abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
+
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
@@ -23,6 +24,7 @@ require 'rspec/rails'
 # require only the support files necessary.
 #
 # Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
+Dir[Rails.root.join('spec/support/**/*.rb')].sort.each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.
@@ -65,4 +67,5 @@ RSpec.configure do |config|
   # config.filter_gems_from_backtrace("gem name")
   config.include FactoryBot::Syntax::Methods
   config.include Sorcery::TestHelpers::Rails::Request, type: :request
+  config.include LoginMacros
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -53,7 +53,7 @@ RSpec.configure do |config|
   #   # is tagged with `:focus`, all examples get run. RSpec also provides
   #   # aliases for `it`, `describe`, and `context` that include `:focus`
   #   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
-  #   config.filter_run_when_matching :focus
+  config.filter_run_when_matching :focus
   #
   #   # Allows RSpec to persist some state between runs in order to support
   #   # the `--only-failures` and `--next-failure` CLI options. We recommend

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,0 +1,5 @@
+RSpec.configure do |config|
+  config.before(:each, type: :system) do
+    driven_by :selenium, using: :headless_chrome, screen_size: [1920, 1080]
+  end
+end

--- a/spec/support/login_macros.rb
+++ b/spec/support/login_macros.rb
@@ -1,0 +1,8 @@
+module LoginMacros
+  def login(user)
+    visit login_path
+    fill_in 'email', with: user.email
+    fill_in 'password', with: 'password'
+    click_button 'ログイン'
+  end
+end

--- a/spec/system/events_spec.rb
+++ b/spec/system/events_spec.rb
@@ -1,0 +1,191 @@
+require 'rails_helper'
+
+RSpec.describe "Events", type: :system do
+  let(:user)  { create :user }
+  let(:event) { create :event }
+
+  describe 'event関係' do
+    context 'index' do
+      before do
+        login(user)
+      end
+
+      it '一覧ページにアクセスすると、イベント一覧を閲覧できる。' do
+        event
+        visit root_path
+        expect(page).to have_content(event.title)
+        expect(page).to have_content(event.prefecture.name)
+        expect(page).to have_content(event.user.name)
+      end
+    end
+
+    context 'new→create' do
+      before do
+        login(user)
+      end
+
+      it '新しくイベント(未来)を作成できる。トップページでそれを確認できる。"直近イベント"でそれを確認できる。' do
+        visit new_event_path
+        fill_in 'Title', with: 'RUNTEQもくもく会'
+        fill_in 'Content', with: '渋谷にあるRUNTEQ教室でもくもく会'
+        fill_in 'Held at', with: '002055-10-02-1300'
+        select '東京都', from: 'Prefecture'
+        click_button '登録'
+
+        expect(page).to have_content('RUNTEQもくもく会')
+        expect(page).to have_content('渋谷にあるRUNTEQ教室でもくもく会')
+        expect(page).to have_content(user.name)
+        expect(page).to have_content('開催前')
+
+        visit root_path
+        expect(page).to have_content('RUNTEQもくもく会')
+        expect(page).to have_content('渋谷にあるRUNTEQ教室でもくもく会')
+        expect(page).to have_content(user.name)
+
+        visit future_events_path
+        expect(page).to have_content('RUNTEQもくもく会')
+        expect(page).to have_content('渋谷にあるRUNTEQ教室でもくもく会')
+        expect(page).to have_content(user.name)
+      end
+
+      it '新しくイベント(過去)を作成できる。ただしトップページでそれは確認できない。"過去イベント"において確認できる。' do
+        visit new_event_path
+        fill_in 'Title', with: 'RUNTEQもくもく会'
+        fill_in 'Content', with: '渋谷にあるRUNTEQ教室でもくもく会'
+        fill_in 'Held at', with: '002014-10-02-1300'
+        select '東京都', from: 'Prefecture'
+        click_button '登録'
+
+        expect(page).to have_content('RUNTEQもくもく会')
+        expect(page).to have_content('渋谷にあるRUNTEQ教室でもくもく会')
+        expect(page).to have_content(user.name)
+        expect(page).to have_content('開催済み')
+
+        visit root_path
+        expect(page).not_to have_content('RUNTEQもくもく会')
+        expect(page).not_to have_content('渋谷にあるRUNTEQ教室でもくもく会')
+        expect(page).not_to have_content(user.name)
+
+        visit past_events_path
+        expect(page).to have_content('RUNTEQもくもく会')
+        expect(page).to have_content('渋谷にあるRUNTEQ教室でもくもく会')
+        expect(page).to have_content(user.name)
+      end
+
+      it 'titleが未記入だと新しいイベントは作成されない。' do
+        visit new_event_path
+        fill_in 'Title', with: ''
+        fill_in 'Content', with: '渋谷にあるRUNTEQ教室でもくもく会'
+        fill_in 'Held at', with: '002055-10-02-1300'
+        select '東京都', from: 'Prefecture'
+        click_button '登録'
+
+        expect(page).to have_content('もくもく会作成')
+      end
+
+      it 'contentが未記入だと新しいイベントは作成されない。' do
+        visit new_event_path
+        fill_in 'Title', with: 'RUNTEQもくもく会'
+        fill_in 'Content', with: ''
+        fill_in 'Held at', with: '002055-10-02-1300'
+        select '東京都', from: 'Prefecture'
+        click_button '登録'
+
+        expect(page).to have_content('もくもく会作成')
+      end
+
+      it 'held_atが未記入だと新しいイベントは作成されない。' do
+        visit new_event_path
+        fill_in 'Title', with: 'RUNTEQもくもく会'
+        fill_in 'Content', with: '渋谷にあるRUNTEQ教室でもくもく会'
+        fill_in 'Held at', with: ''
+        select '東京都', from: 'Prefecture'
+        click_button '登録'
+
+        expect(page).to have_content('もくもく会作成')
+      end
+    end
+
+    context 'edit→update' do
+      before do
+        login(event.user)
+      end
+
+      it 'イベント(未来)を更新できる。トップページでそれを確認できる。' do
+        visit edit_event_path(event)
+        fill_in 'Title', with: 'RUNTEQもくもく会'
+        fill_in 'Content', with: '渋谷にあるRUNTEQ教室でもくもく会'
+        fill_in 'Held at', with: '002055-10-02-1300'
+        select '東京都', from: 'Prefecture'
+        click_button '登録'
+
+        expect(page).to have_content('RUNTEQもくもく会')
+        expect(page).to have_content('渋谷にあるRUNTEQ教室でもくもく会')
+        expect(page).to have_content(event.user.name)
+        expect(page).to have_content('開催前')
+
+        visit root_path
+        expect(page).to have_content('RUNTEQもくもく会')
+        expect(page).to have_content('渋谷にあるRUNTEQ教室でもくもく会')
+        expect(page).to have_content(event.user.name)
+      end
+
+      it 'イベント(過去)を更新できる。ただしトップページでそれは確認できない。"過去イベント"において確認できる。' do
+        visit edit_event_path(event)
+        fill_in 'Title', with: 'RUNTEQもくもく会'
+        fill_in 'Content', with: '渋谷にあるRUNTEQ教室でもくもく会'
+        fill_in 'Held at', with: '002014-10-02-1300'
+        select '東京都', from: 'Prefecture'
+        click_button '登録'
+
+        expect(page).to have_content('RUNTEQもくもく会')
+        expect(page).to have_content('渋谷にあるRUNTEQ教室でもくもく会')
+        expect(page).to have_content(event.user.name)
+        expect(page).to have_content('開催済み')
+
+        visit root_path
+        expect(page).not_to have_content('RUNTEQもくもく会')
+        expect(page).not_to have_content('渋谷にあるRUNTEQ教室でもくもく会')
+        expect(page).not_to have_content(event.user.name)
+
+        visit past_events_path
+        expect(page).to have_content('RUNTEQもくもく会')
+        expect(page).to have_content('渋谷にあるRUNTEQ教室でもくもく会')
+        expect(page).to have_content(event.user.name)
+      end
+
+      it 'titleが未記入だと新しいイベントは作成されない。' do
+        visit edit_event_path(event)
+        fill_in 'Title', with: ''
+        fill_in 'Content', with: '渋谷にあるRUNTEQ教室でもくもく会'
+        fill_in 'Held at', with: '002055-10-02-1300'
+        select '東京都', from: 'Prefecture'
+        click_button '登録'
+
+        expect(page).to have_content('もくもく会編集')
+      end
+
+      it 'contentが未記入だと新しいイベントは作成されない。' do
+        visit edit_event_path(event)
+        fill_in 'Title', with: 'RUNTEQもくもく会'
+        fill_in 'Content', with: ''
+        fill_in 'Held at', with: '002055-10-02-1300'
+        select '東京都', from: 'Prefecture'
+        click_button '登録'
+
+        expect(page).to have_content('もくもく会編集')
+      end
+
+      it 'held_atが未記入だと新しいイベントは作成されない。' do
+        visit edit_event_path(event)
+        fill_in 'Title', with: 'RUNTEQもくもく会'
+        fill_in 'Content', with: '渋谷にあるRUNTEQ教室でもくもく会'
+        fill_in 'Held at', with: ''
+        select '東京都', from: 'Prefecture'
+        click_button '登録'
+
+        expect(page).to have_content('もくもく会編集')
+      end
+    end
+  end
+end

--- a/spec/system/sessions_spec.rb
+++ b/spec/system/sessions_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe "Sessions", type: :system do
+  let(:user) { create :user }
+
+  describe 'session関係' do
+    it '登録されているユーザーでログインを行い、イベント一覧ページにリダイレクトされる。' do
+      visit login_path
+      fill_in 'email', with: user.email
+      fill_in 'password', with: 'password'
+      click_button 'ログイン'
+
+      expect(page).to have_content('もくもく会を作る')
+    end
+
+    it '登録されていないユーザーでログインを行うと、ログインページが表示される。' do
+      visit login_path
+      fill_in 'email', with: 'hogehogee4674@exmaple.com'
+      fill_in 'password', with: 'password'
+      click_button 'ログイン'
+
+      expect(page).to have_content('Sign up')
+      expect(page).not_to have_content('I agree to the Terms of Service and Privacy Policy.')
+    end
+  end
+end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -1,0 +1,111 @@
+require 'rails_helper'
+
+RSpec.describe "Users", type: :system do
+  describe 'Sign up関係' do
+    context '成功系' do
+      it 'Sign upを行い、ログイン処理を行うとイベント一覧ページにリダイレクトされる。' do
+        visit signup_path
+        fill_in 'Name', with: 'らんてくん'
+        fill_in 'Email', with: 'sample@example.com'
+        fill_in 'Password', with: 'password'
+        fill_in 'Password confirmation', with: 'password'
+        click_button '登録'
+
+        visit login_path
+        fill_in 'email', with: 'sample@example.com'
+        fill_in 'password', with: 'password'
+        click_button 'ログイン'
+
+        expect(page).to have_content('もくもく会を作る')
+      end
+
+      it 'Sign up時に性別を選ばないで登録すると、その他として登録される。' do
+        visit signup_path
+        fill_in 'Name', with: 'らんてくん'
+        fill_in 'Email', with: 'sample@example.com'
+        fill_in 'Password', with: 'password'
+        fill_in 'Password confirmation', with: 'password'
+        click_button '登録'
+
+        visit login_path
+        fill_in 'email', with: 'sample@example.com'
+        fill_in 'password', with: 'password'
+        click_button 'ログイン'
+
+        expect(page).to have_content('もくもく会を作る')
+        expect(User.last.gender).to eq 'other'
+      end
+
+      it 'Sign up時に性別(男性)を選んで登録することができる。' do
+        visit signup_path
+        fill_in 'Name', with: 'らんてくん'
+        fill_in 'Email', with: 'sample@example.com'
+        fill_in 'Password', with: 'password'
+        fill_in 'Password confirmation', with: 'password'
+        select '男性', from: 'Gender'
+        click_button '登録'
+
+        visit login_path
+        fill_in 'email', with: 'sample@example.com'
+        fill_in 'password', with: 'password'
+        click_button 'ログイン'
+
+        expect(page).to have_content('もくもく会を作る')
+        expect(User.last.gender).to eq 'man'
+      end
+
+      it 'Sign up時に性別(女性)を選んで登録することができる。' do
+        visit signup_path
+        fill_in 'Name', with: 'らんてくん'
+        fill_in 'Email', with: 'sample@example.com'
+        fill_in 'Password', with: 'password'
+        fill_in 'Password confirmation', with: 'password'
+        select '女性', from: 'Gender'
+        click_button '登録'
+
+        visit login_path
+        fill_in 'email', with: 'sample@example.com'
+        fill_in 'password', with: 'password'
+        click_button 'ログイン'
+
+        expect(page).to have_content('もくもく会を作る')
+        expect(User.last.gender).to eq 'woman'
+      end
+    end
+
+    context '失敗系' do
+      it 'passwordが未入力だと。Sign upページが表示される。' do
+        visit signup_path
+        fill_in 'Name', with: 'らんてくん'
+        fill_in 'Email', with: 'sample@example.com'
+        fill_in 'Password', with: ''
+        fill_in 'Password confirmation', with: 'password'
+        click_button '登録'
+
+        expect(page).to have_content('I agree to the Terms of Service and Privacy Policy.')
+      end
+
+      it 'password_confirmationが未入力だと。Sign upページが表示される。' do
+        visit signup_path
+        fill_in 'Name', with: 'らんてくん'
+        fill_in 'Email', with: 'sample@example.com'
+        fill_in 'Password', with: 'password'
+        fill_in 'Password confirmation', with: ''
+        click_button '登録'
+
+        expect(page).to have_content('I agree to the Terms of Service and Privacy Policy.')
+      end
+
+      it 'password, password_confirmationが未入力だと。Sign upページが表示される。' do
+        visit signup_path
+        fill_in 'Name', with: 'らんてくん'
+        fill_in 'Email', with: 'sample@example.com'
+        fill_in 'Password', with: ''
+        fill_in 'Password confirmation', with: ''
+        click_button '登録'
+
+        expect(page).to have_content('I agree to the Terms of Service and Privacy Policy.')
+      end
+    end
+  end
+end

--- a/spec/system/woman_only_events_spec.rb
+++ b/spec/system/woman_only_events_spec.rb
@@ -1,0 +1,109 @@
+require 'rails_helper'
+
+RSpec.describe "WomanOnlyEvents", type: :system do
+  let(:user)  { create :user }
+  let(:woman) { create :user, :woman_user }
+  let(:event) { create :event }
+  let(:woman_only_event) { create :event, :woman_only_event }
+
+  describe '女性限定event' do
+    context '女性以外のユーザーがログインした場合' do
+      before do
+        woman_only_event
+        login(user)
+      end
+
+      it '一覧に"女性限定"の表記のイベントがある。' do
+        visit root_path
+        expect(page).to have_content(woman_only_event.title)
+        expect(page).to have_content('女性限定')
+      end
+
+      it '"女性限定"イベントには参加できない。' do
+        visit event_path(woman_only_event)
+        expect(page).to have_content(woman_only_event.title)
+        expect(page).to have_content('女性限定')
+        expect(page).not_to have_content('このもくもく会に参加する')
+      end
+
+      it '新規イベント作成時に"Only woman"チェックボックスが表示されない。' do
+        visit new_event_path
+        expect(page).to have_content('もくもく会作成')
+        expect(page).not_to have_content('Only woman')
+      end
+    end
+
+    context '女性ユーザーがログインした場合' do
+      before do
+        woman_only_event
+        login(woman)
+      end
+
+      it '一覧に"女性限定"の表記のイベントがある。' do
+        visit root_path
+        expect(page).to have_content(woman_only_event.title)
+        expect(page).to have_content('女性限定')
+      end
+
+      it '"女性限定"イベントに参加できる。' do
+        visit event_path(woman_only_event)
+        expect(page).to have_content(woman_only_event.title)
+        expect(page).to have_content('女性限定')
+        expect(page).to have_content('このもくもく会に参加する')
+
+        click_link 'このもくもく会に参加する'
+      end
+
+      it '"女性限定"イベントを作成できる。' do
+        visit new_event_path
+        fill_in 'Title', with: 'RUNTEQもくもく会-woman-'
+        fill_in 'Content', with: '渋谷にあるRUNTEQ教室でもくもく会-woman-'
+        fill_in 'Held at', with: '002055-10-02-1300'
+        select '東京都', from: 'Prefecture'
+        find('#event_only_woman').click
+        click_button '登録'
+
+        expect(page).to have_content('RUNTEQもくもく会-woman-')
+        expect(page).to have_content('渋谷にあるRUNTEQ教室でもくもく会-woman-')
+        expect(page).to have_content(woman.name)
+        expect(page).to have_content('開催前')
+        expect(page).to have_content('女性限定')
+
+        visit root_path
+        expect(page).to have_content('RUNTEQもくもく会-woman-')
+        expect(page).to have_content('渋谷にあるRUNTEQ教室でもくもく会-woman-')
+        expect(page).to have_content(woman.name)
+        expect(page).to have_content('女性限定')
+      end
+
+      it '"女性限定"イベントを更新できる。' do
+        visit new_event_path
+        fill_in 'Title', with: 'RUNTEQもくもく会-vol2-'
+        fill_in 'Content', with: '渋谷にあるRUNTEQ教室でもくもく会-vol2-'
+        fill_in 'Held at', with: '002055-10-02-1300'
+        select '東京都', from: 'Prefecture'
+        click_button '登録'
+
+        visit edit_event_path(woman.events.last)
+        fill_in 'Title', with: 'RUNTEQもくもく会-woman vol2-'
+        fill_in 'Content', with: '渋谷にあるRUNTEQ教室でもくもく会-woman vol2-'
+        fill_in 'Held at', with: '002055-10-02-1300'
+        select '東京都', from: 'Prefecture'
+        find('#event_only_woman').click
+        click_button '登録'
+
+        expect(page).to have_content('RUNTEQもくもく会-woman vol2-')
+        expect(page).to have_content('渋谷にあるRUNTEQ教室でもくもく会-woman vol2-')
+        expect(page).to have_content(woman.name)
+        expect(page).to have_content('開催前')
+        expect(page).to have_content('女性限定')
+
+        visit root_path
+        expect(page).to have_content('RUNTEQもくもく会-woman vol2-')
+        expect(page).to have_content('渋谷にあるRUNTEQ教室でもくもく会-woman vol2-')
+        expect(page).to have_content(woman.name)
+        expect(page).to have_content('女性限定')
+      end
+    end
+  end
+end

--- a/spec/system/woman_users_spec.rb
+++ b/spec/system/woman_users_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe "WomanUsers", type: :system do
+  let(:user)  { create :user }
+  let(:woman) { create :user, :woman}
+  let(:event) { create :event }
+
+  describe 'womanがログインした場合' do
+    before do
+      login(woman)
+      event
+    end
+
+    it '一覧ページにアクセスすると、イベント一覧にアクセスでき、イベント(一般)を閲覧できる。' do
+      visit root_path
+      expect(page).to have_content(event.title)
+      expect(page).to have_content(event.prefecture.name)
+      expect(page).to have_content(event.user.name)
+    end
+
+    it '一般イベントに参加することができる。' do
+      visit event_path(event)
+      expect(page).to have_content(event.title)
+      expect(page).to have_content(event.user.name)
+      expect(page).not_to have_content('女性限定')
+      expect(page).to have_content('このもくもく会に参加する')
+    end
+  end
+end


### PR DESCRIPTION
**概要**
下記の機能を追加

- ユーザー登録時に手入力やチェックボックス入力ではなく、セレクト形式で性別登録できる。
- イベント作成画面にOnly womanのチェックボックスにチェックを入れるだけで女性限定イベントを作できる。
- ユーザーが女性以外の場合、イベント作成時にOnly womanは表示されず、女性限定イベントが作成できない。
- 女性限定イベントには女性のみが参加できる。
- 女性以外の場合、女性限定イベントの詳細ページを開いた際に「このもくもく会に参加する」が表示されない。
- 女性限定イベントは一覧・詳細画面にて「女性限定」が表記される。

**確認方法**
テストの実施

[![Image from Gyazo](https://i.gyazo.com/708e6ccfe3b3198d56a5eb14dbf584dc.png)](https://gyazo.com/708e6ccfe3b3198d56a5eb14dbf584dc)